### PR TITLE
Added Retry Policy for SendRequestAsync

### DIFF
--- a/KickLib.Api.Unofficial/Clients/BrowserClient.cs
+++ b/KickLib.Api.Unofficial/Clients/BrowserClient.cs
@@ -45,7 +45,7 @@ namespace KickLib.Api.Unofficial.Clients
             // Polly retry policy: 3 attempts with 5 seconds delay between each attempt
             var retryPolicy = Policy
                 .Handle<Exception>() // Handle all exceptions
-                .Or<OperationException>() // Handle specific exceptions
+                .Or<InvalidOperationException>() // Handle specific exceptions
                 .WaitAndRetryAsync(
                     retryCount: 3,
                     sleepDurationProvider: retryAttempt => TimeSpan.FromSeconds(5),


### PR DESCRIPTION
Sometimes a 504 timeout error occurs, so I added a policy to wait for 5 seconds and then retry. This prevents the process from getting stuck and allows it to retrieve the chatRoomId on the next attempt.